### PR TITLE
constification of methods

### DIFF
--- a/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp
+++ b/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp
@@ -805,7 +805,7 @@ char * videoInput::getDeviceName(int deviceID){
 //
 // ----------------------------------------------------------------------
 
-int videoInput::getDeviceIDFromName(char * name) {
+int videoInput::getDeviceIDFromName(const char * name) {
 
 	if (listDevices(true) == 0) return -1;
 

--- a/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp
+++ b/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp
@@ -792,7 +792,7 @@ bool videoInput::setFormat(int deviceNumber, int format){
 // ----------------------------------------------------------------------
 char videoInput::deviceNames[VI_MAX_CAMERAS][255]={{0}};
 
-char * videoInput::getDeviceName(int deviceID){
+const char * videoInput::getDeviceName(int deviceID){
 	if( deviceID >= VI_MAX_CAMERAS ){
 		return NULL;
 	}

--- a/videoInputSrcAndDemos/libs/videoInput/videoInput.h
+++ b/videoInputSrcAndDemos/libs/videoInput/videoInput.h
@@ -273,7 +273,7 @@ class videoInput{
 
 		//needs to be called after listDevices - otherwise returns NULL
 		static char * getDeviceName(int deviceID);
-		static int getDeviceIDFromName(char * name);
+		static int getDeviceIDFromName(const char * name);
 
 		//choose to use callback based capture - or single threaded
 		void setUseCallback(bool useCallback);

--- a/videoInputSrcAndDemos/libs/videoInput/videoInput.h
+++ b/videoInputSrcAndDemos/libs/videoInput/videoInput.h
@@ -272,7 +272,7 @@ class videoInput{
 		static std::vector <std::string> getDeviceList(); 
 
 		//needs to be called after listDevices - otherwise returns NULL
-		static char * getDeviceName(int deviceID);
+		static const char * getDeviceName(int deviceID);
 		static int getDeviceIDFromName(const char * name);
 
 		//choose to use callback based capture - or single threaded


### PR DESCRIPTION
methods handling with device-names should really use `const char*` for the device names (both as an argument and as a result)