### PR TITLE
fixes memory leak warnings on clang

### DIFF
--- a/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp
+++ b/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp
@@ -487,17 +487,6 @@ videoDevice::~videoDevice(){
 								(pGraph) = 0;
 	}
 
-	//delete our pointers
-	delete pDestFilter;
-	delete pVideoInputFilter;
-	delete pGrabberF;
-	delete pGrabber;
-	delete pControl;
-	delete streamConf;
-	delete pMediaEvent;
-	delete pCaptureGraph;
-	delete pGraph;
-
 	if(verbose)printf("SETUP: Device %i disconnected and freed\n\n",myID);
 }
 


### PR DESCRIPTION
compiling with clang i got some warnings in:

https://github.com/ofTheo/videoInput/blob/master/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp#L491-L499

those deletes are being done on the interfaces which don't have a virtual destructor so the real object's destructor won't get called. 

looking into the code a bit more, though by the time those deletes are executed the pointers are already null since they've been released here:

https://github.com/ofTheo/videoInput/blob/master/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp#L438-L488