### PR TITLE
Fix warnings

### DIFF
--- a/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp
+++ b/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp
@@ -336,15 +336,11 @@ void videoDevice::NukeDownstream(IBaseFilter *pBF){
 // ----------------------------------------------------------------------
 
 void videoDevice::destroyGraph(){
-	HRESULT hr = NULL;
- 	int FuncRetval=0;
- 	int NumFilters=0;
+	HRESULT hr = NOERROR;
 
-	int i = 0;
 	while (hr == NOERROR)
 	{
-		IEnumFilters * pEnum = 0;
-		ULONG cFetched;
+		IEnumFilters * pEnum = NULL;
 
 		// We must get the enumerator again every time because removing a filter from the graph
 		// invalidates the enumerator. We always get only the first filter from each enumerator.
@@ -352,26 +348,16 @@ void videoDevice::destroyGraph(){
 		if (FAILED(hr)) { if(verbose)printf("SETUP: pGraph->EnumFilters() failed. \n"); return; }
 
 		IBaseFilter * pFilter = NULL;
-		if (pEnum->Next(1, &pFilter, &cFetched) == S_OK)
+		if (pEnum->Next(1, &pFilter, NULL) == S_OK)
 		{
 			FILTER_INFO FilterInfo={0};
 			hr = pFilter->QueryFilterInfo(&FilterInfo);
 			FilterInfo.pGraph->Release();
 
-			int count = 0;
-			char buffer[255];
-			memset(buffer, 0, 255 * sizeof(char));
-
-			while( FilterInfo.achName[count] != 0x00 )
-			{
-				buffer[count] = static_cast<char>(FilterInfo.achName[count]);
-				count++;
-			}
-
-			if(verbose)printf("SETUP: removing filter %s...\n", buffer);
+			if(verbose)printf("SETUP: removing filter %ls...\n", FilterInfo.achName);
 			hr = pGraph->RemoveFilter(pFilter);
 			if (FAILED(hr)) { if(verbose)printf("SETUP: pGraph->RemoveFilter() failed. \n"); return; }
-			if(verbose)printf("SETUP: filter removed %s  \n",buffer);
+			if(verbose)printf("SETUP: filter removed %ls  \n", FilterInfo.achName);
 
 			pFilter->Release();
 			pFilter = NULL;
@@ -379,10 +365,7 @@ void videoDevice::destroyGraph(){
 		else hr = 1;
 		pEnum->Release();
 		pEnum = NULL;
-		i++;
 	}
-
- return;
 }
 
 

--- a/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp
+++ b/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp
@@ -162,7 +162,7 @@ public:
 
 
 	//------------------------------------------------
-    STDMETHODIMP QueryInterface(REFIID riid, void **ppvObject){
+    STDMETHODIMP QueryInterface(REFIID /*riid*/, void **ppvObject){
         *ppvObject = static_cast<ISampleGrabberCB*>(this);
         return S_OK;
     }
@@ -170,7 +170,7 @@ public:
 
     //This method is meant to have less overhead
 	//------------------------------------------------
-    STDMETHODIMP SampleCB(double Time, IMediaSample *pSample){
+    STDMETHODIMP SampleCB(double /*Time*/, IMediaSample *pSample){
     	if(WaitForSingleObject(hEvent, 0) == WAIT_OBJECT_0) return S_OK;
 
     	HRESULT hr = pSample->GetPointer(&ptrBuffer);
@@ -194,7 +194,7 @@ public:
 
 
     //This method is meant to have more overhead
-    STDMETHODIMP BufferCB(double Time, BYTE *pBuffer, long BufferLen){
+    STDMETHODIMP BufferCB(double /*Time*/, BYTE * /*pBuffer*/, long /*BufferLen*/){
     	return E_NOTIMPL;
     }
 
@@ -1135,7 +1135,6 @@ bool videoInput::getVideoSettingFilter(int deviceID, long Property, long &min, l
 	if( !isDeviceSetup(deviceID) )return false;
 
 	HRESULT hr;
-	bool isSuccessful = false;
 
 	videoDevice * VD = VDList[deviceID];
 
@@ -1211,7 +1210,6 @@ bool videoInput::setVideoSettingFilter(int deviceID, long Property, long lValue,
 	if( !isDeviceSetup(deviceID) )return false;
 
 	HRESULT hr;
-	bool isSuccessful = false;
 
 	videoDevice * VD = VDList[deviceID];
 
@@ -1334,7 +1332,6 @@ bool videoInput::getVideoSettingCamera(int deviceID, long Property, long &min, l
 	if( !isDeviceSetup(deviceID) )return false;
 
 	HRESULT hr;
-	bool isSuccessful = false;
 
 	videoDevice * VD = VDList[deviceID];
 
@@ -1577,10 +1574,6 @@ void videoInput::processPixels(unsigned char * src, unsigned char * dst, int wid
 	int numBytes = widthInBytes * height;
 
 	if(!bRGB){
-
-		int x = 0;
-		int y = 0;
-
 		if(bFlip){
 			for(int y = 0; y < height; y++){
 				memcpy(dst + (y * widthInBytes), src + ( (height -y -1) * widthInBytes), widthInBytes);
@@ -1770,6 +1763,7 @@ static bool setSizeAndSubtype(videoDevice * VD, int attemptWidth, int attemptHei
 	VIDEOINFOHEADER *pVih =  reinterpret_cast<VIDEOINFOHEADER*>(VD->pAmMediaType->pbFormat);
 
 	//store current size
+	// XX: Should they be reset somewhere?
 	int tmpWidth  = HEADER(pVih)->biWidth;
 	int tmpHeight = HEADER(pVih)->biHeight;
 	AM_MEDIA_TYPE * tmpType = NULL;

--- a/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp
+++ b/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp
@@ -801,7 +801,7 @@ std::vector <std::string> videoInput::getDeviceList(){
 	int numDev = videoInput::listDevices(true);
 	std::vector <std::string> deviceList; 
 	for(int i = 0; i < numDev; i++){
-		char * name =  videoInput::getDeviceName(i); 
+		const char * name =  videoInput::getDeviceName(i);
 		if( name == NULL )break; 
 		deviceList.push_back(name); 
 	}


### PR DESCRIPTION
Sorry, it took me quite a whoile to come back to this (https://github.com/ofTheo/videoInput/issues/38) 

This PR 
- fixes some warnings about unused variables/parameters that creep up on /W4, 
- fixes a compilation error about `char*` getting assigned to `const char*`  
- simplifies `videoDevice::destroyGraph` a bit

Disclaimer: I only tested whether it compiles with VS2017 and didn't run any elaborate tests.
