### PR TITLE
Fix potential index mismatch in the deviceNames and deviceUniqueNames arrays for the same device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ obj/
 #vs files
 [Dd]ebug/
 [Rr]elease/
+.vs/
 *.opensdf
 *.pdb
 *.idb

--- a/videoInputSrcAndDemos/VS-videoInputcompileAsLib/videoInput.vcxproj
+++ b/videoInputSrcAndDemos/VS-videoInputcompileAsLib/videoInput.vcxproj
@@ -22,13 +22,14 @@
     <ProjectGuid>{0D49DFE2-6BF1-4AA3-95B7-010FB9273F5F}</ProjectGuid>
     <RootNamespace>videoInput</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v90</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
@@ -39,7 +40,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v90</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>

--- a/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp
+++ b/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp
@@ -887,6 +887,26 @@ int videoInput::listDevices(bool silent){
 			        continue;  // Skip this one, maybe the next one will work.
 			    }
 
+				// Find unique name
+				bool hasUniqueName = false;
+
+				IMalloc *pMalloc = NULL;
+				hr = CoGetMalloc(1, (LPMALLOC*)&pMalloc);
+
+				if (SUCCEEDED(hr)){
+					BSTR uniqueName = NULL;
+					hr = pMoniker->GetDisplayName(NULL, NULL, &uniqueName);
+					if (SUCCEEDED(hr)) {
+						deviceUniqueNames.push_back(uniqueName);
+						hasUniqueName = true;
+						pMalloc->Free(uniqueName);
+					}
+					pMalloc->Release();
+				}
+
+				if (!hasUniqueName)
+					deviceUniqueNames.push_back(std::wstring());
+
  				// Find the description or friendly name.
 			    VARIANT varName;
 			    VariantInit(&varName);
@@ -907,26 +927,6 @@ int videoInput::listDevices(bool silent){
 					deviceNames[deviceCounter][count] = 0;
 
 			        if(!silent)printf("SETUP: %i) %s \n",deviceCounter, deviceNames[deviceCounter]);
-
-					// Find unique name
-					bool hasUniqueName = false;
-
-					IMalloc *pMalloc = NULL;
-					hr = CoGetMalloc(1, (LPMALLOC*)&pMalloc);
-
-					if (SUCCEEDED(hr)) {
-						BSTR uniqueName = NULL;
-						hr = pMoniker->GetDisplayName(NULL, NULL, &uniqueName);
-						if (SUCCEEDED(hr)) {
-							deviceUniqueNames.push_back(uniqueName);
-							hasUniqueName = true;
-							pMalloc->Free(uniqueName);
-						}
-						pMalloc->Release();
-					}
-
-					if (!hasUniqueName)
-						deviceUniqueNames.push_back(std::wstring());
 			    }
 
 			    pPropBag->Release();

--- a/videoInputSrcAndDemos/libs/videoInput/videoInput.h
+++ b/videoInputSrcAndDemos/libs/videoInput/videoInput.h
@@ -275,6 +275,10 @@ class videoInput{
 		static const char * getDeviceName(int deviceID);
 		static int getDeviceIDFromName(const char * name);
 
+		//needs to be called after listDevices - otherwise returns empty string
+		static const std::wstring& getUniqueDeviceName(int deviceID);
+		static int getDeviceIDFromUniqueName(const std::wstring& uniqueName);
+
 		//choose to use callback based capture - or single threaded
 		void setUseCallback(bool useCallback);
 
@@ -402,6 +406,8 @@ class videoInput{
 		static void __cdecl basicThread(void * objPtr);
 
 		static char deviceNames[VI_MAX_CAMERAS][255];
+
+		static std::vector<std::wstring> deviceUniqueNames;
 
 };
 


### PR DESCRIPTION
Hi @ofTheo! 

The issue is - even if "FriendlyName" query fails `deviceCounter` is increased, but `deviceUniqueNames` size remains the same - so we could face an index mismatch for the same device in the two arrays.

The solution is we should add string to `deviceUniqueNames` array regardless of "FriendlyName" query status.

`deviceNames` is a vector of FriendlyNames and is initialized with 255 empty strings:

https://github.com/ofTheo/videoInput/blob/870dbabda79470736e5d5294038ae5676ebb238a/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp#L770

So we have initially 255 devices whose FriendlyNames are updated after `listDevices()` is called. And we just skip device in `deviceNames` if FriendlyName query is failed leaving it empty, but `deviceUniqueNames` size is not increased for this device, and we have index mismatch, and the methods:

https://github.com/ofTheo/videoInput/blob/870dbabda79470736e5d5294038ae5676ebb238a/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp#L786  

and 

https://github.com/ofTheo/videoInput/blob/870dbabda79470736e5d5294038ae5676ebb238a/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp#L812

may not return same index for the same device afterwards.