### PR TITLE
Fix potential index mismatch in the deviceNames and deviceUniqueNames arrays for the same device

### DIFF
--- a/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp
+++ b/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp
@@ -887,6 +887,26 @@ int videoInput::listDevices(bool silent){
 			        continue;  // Skip this one, maybe the next one will work.
 			    }
 
+				// Find unique name
+				bool hasUniqueName = false;
+
+				IMalloc *pMalloc = NULL;
+				hr = CoGetMalloc(1, (LPMALLOC*)&pMalloc);
+
+				if (SUCCEEDED(hr)){
+					BSTR uniqueName = NULL;
+					hr = pMoniker->GetDisplayName(NULL, NULL, &uniqueName);
+					if (SUCCEEDED(hr)) {
+						deviceUniqueNames.push_back(uniqueName);
+						hasUniqueName = true;
+						pMalloc->Free(uniqueName);
+					}
+					pMalloc->Release();
+				}
+
+				if (!hasUniqueName)
+					deviceUniqueNames.push_back(std::wstring());
+
  				// Find the description or friendly name.
 			    VARIANT varName;
 			    VariantInit(&varName);
@@ -907,26 +927,6 @@ int videoInput::listDevices(bool silent){
 					deviceNames[deviceCounter][count] = 0;
 
 			        if(!silent)printf("SETUP: %i) %s \n",deviceCounter, deviceNames[deviceCounter]);
-
-					// Find unique name
-					bool hasUniqueName = false;
-
-					IMalloc *pMalloc = NULL;
-					hr = CoGetMalloc(1, (LPMALLOC*)&pMalloc);
-
-					if (SUCCEEDED(hr)) {
-						BSTR uniqueName = NULL;
-						hr = pMoniker->GetDisplayName(NULL, NULL, &uniqueName);
-						if (SUCCEEDED(hr)) {
-							deviceUniqueNames.push_back(uniqueName);
-							hasUniqueName = true;
-							pMalloc->Free(uniqueName);
-						}
-						pMalloc->Release();
-					}
-
-					if (!hasUniqueName)
-						deviceUniqueNames.push_back(std::wstring());
 			    }
 
 			    pPropBag->Release();

--- a/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp
+++ b/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp
@@ -887,26 +887,6 @@ int videoInput::listDevices(bool silent){
 			        continue;  // Skip this one, maybe the next one will work.
 			    }
 
-				// Find unique name
-				bool hasUniqueName = false;
-
-				IMalloc *pMalloc = NULL;
-				hr = CoGetMalloc(1, (LPMALLOC*)&pMalloc);
-
-				if (SUCCEEDED(hr)){
-					BSTR uniqueName = NULL;
-					hr = pMoniker->GetDisplayName(NULL, NULL, &uniqueName);
-					if (SUCCEEDED(hr)) {
-						deviceUniqueNames.push_back(uniqueName);
-						hasUniqueName = true;
-						pMalloc->Free(uniqueName);
-					}
-					pMalloc->Release();
-				}
-
-				if (!hasUniqueName)
-					deviceUniqueNames.push_back(std::wstring());
-
  				// Find the description or friendly name.
 			    VARIANT varName;
 			    VariantInit(&varName);
@@ -928,6 +908,30 @@ int videoInput::listDevices(bool silent){
 
 			        if(!silent)printf("SETUP: %i) %s \n",deviceCounter, deviceNames[deviceCounter]);
 			    }
+
+				// Find unique name
+				IMalloc* pMalloc = NULL;
+				hr = CoGetMalloc(1, (LPMALLOC*)&pMalloc);
+
+				if (SUCCEEDED(hr)) {
+					BSTR uniqueName = NULL;
+					hr = pMoniker->GetDisplayName(NULL, NULL, &uniqueName);
+					if (SUCCEEDED(hr)) {
+						deviceUniqueNames.push_back(uniqueName);
+						pMalloc->Free(uniqueName);
+					}
+					else {
+						const BSTR friendlyName = varName.bstrVal;
+
+						if (SysStringLen(friendlyName) != 0) {
+							deviceUniqueNames.push_back(friendlyName);
+						}
+						else {
+							deviceUniqueNames.push_back(std::wstring());
+						}
+					}
+					pMalloc->Release();
+				}
 
 			    pPropBag->Release();
 			    pPropBag = NULL;


### PR DESCRIPTION
Hi, @ofTheo! 

The issue is - even if "FriendlyName" query fails `deviceCounter` is increased, but `deviceUniqueNames` size remains the same - so we could face an index mismatch for the same device in the two arrays.

The solution is we should add string to `deviceUniqueNames` array regardless of "FriendlyName" query status.

`deviceNames` is a vector of FriendlyNames and is initialized with 255 empty strings:

https://github.com/ofTheo/videoInput/blob/870dbabda79470736e5d5294038ae5676ebb238a/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp#L770

So we have initially 255 devices whose FriendlyNames are updated after `listDevices()` is called. And we just skip device in `deviceNames` if FriendlyName query is failed leaving it empty, but `deviceUniqueNames` size is not increased for this device, and we have index mismatch, and the methods:

https://github.com/ofTheo/videoInput/blob/870dbabda79470736e5d5294038ae5676ebb238a/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp#L786  

and 

https://github.com/ofTheo/videoInput/blob/870dbabda79470736e5d5294038ae5676ebb238a/videoInputSrcAndDemos/libs/videoInput/videoInput.cpp#L812

may not return same index for the same device afterwards.