### PR TITLE
CMake Support for videoInput library 

### DIFF
--- a/videoInputSrcAndDemos/libs/videoInput/CMakeLists.txt
+++ b/videoInputSrcAndDemos/libs/videoInput/CMakeLists.txt
@@ -11,10 +11,10 @@ set(HEADERS
 )
 
 # Define the target for the videoInput library
-add_library(videoinput STATIC ${SOURCES} ${HEADERS})
+add_library(videoInput STATIC ${SOURCES} ${HEADERS})
 
 # Set compiler options
-target_compile_options(videoinput PRIVATE -O3)
+target_compile_options(videoInput PRIVATE -O3)
 
 # Set include directories for the library
-target_include_directories(videoinput PUBLIC ./)
+target_include_directories(videoInput PUBLIC ./)

--- a/videoInputSrcAndDemos/libs/videoInput/CMakeLists.txt
+++ b/videoInputSrcAndDemos/libs/videoInput/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.12)
+project(VideoInputLibrary VERSION 1.0)
+
+
+set(SOURCES
+    videoInput.cpp
+)
+
+set(HEADERS
+   videoInput.h
+)
+
+# Define the target for the videoInput library
+add_library(videoinput STATIC ${SOURCES} ${HEADERS})
+
+# Set compiler options
+target_compile_options(videoinput PRIVATE -O3)
+
+# Set include directories for the library
+target_include_directories(videoinput PUBLIC ./)


### PR DESCRIPTION
CMake Support for core library

+ this allows compiling the videoInput for all new platforms / architectures :

With this can target VS 64 / VS ARM64 easily 

In apothecary: 
```
cd videoInputSrcAndDemos

	echoVerbose "building $TYPE | $ARCH | $VS_VER | vs: $VS_VER_GEN"
        echoVerbose "--------------------"
        GENERATOR_NAME="Visual Studio ${VS_VER_GEN}" 
        mkdir -p "build_${TYPE}_${ARCH}"
        cd "build_${TYPE}_${ARCH}"
        DEFS="
            -DCMAKE_BUILD_TYPE=Release \
            -DCMAKE_C_STANDARD=17 \
            -DCMAKE_CXX_STANDARD=17 \
            -DCMAKE_CXX_STANDARD_REQUIRED=ON \
            -DCMAKE_CXX_EXTENSIONS=OFF
            -DBUILD_SHARED_LIBS=ON \
            -DCMAKE_INSTALL_PREFIX=Release \
            -DCMAKE_INCLUDE_OUTPUT_DIRECTORY=include \
            -DCMAKE_INSTALL_INCLUDEDIR=include"
         
        cmake ../libs/videoInput ${DEFS} \
            -A "${PLATFORM}" \
            -G "${GENERATOR_NAME}" \
            -DCMAKE_INSTALL_PREFIX=Release \
            -D CMAKE_VERBOSE_MAKEFILE=ON \
		    -D BUILD_SHARED_LIBS=ON 
        cmake --build . --config Release
 
        cd ..	
	```